### PR TITLE
Add PCD downloading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ const sandingSummaryName = "sanding-summary";
 function App() {
   const [passSummaries, setPassSummaries] = useState<Pass[]>([]);
   const [files, setFiles] = useState<VIAM.dataApi.BinaryData[]>([]);
+  const [viamClient, setViamClient] = useState<VIAM.ViamClient | null>(null);
   // const [sanderClient, setSanderClient] = useState<VIAM.GenericComponentClient | null>(null);
   const [videoStoreClient, setVideoStoreClient] = useState<VIAM.GenericComponentClient | null>(null);
   // const [robotClient, setRobotClient] = useState<VIAM.RobotClient | null>(null);
@@ -48,6 +49,7 @@ function App() {
       } as VIAM.dataApi.Filter;
       
       const viamClient = await connect(apiKeyId, apiKeySecret);
+      setViamClient(viamClient);
       // const robotClient = await viamClient.connectToMachine({host: hostname, id: machineId});
       // setRobotClient(robotClient); // Store the robot client
       // const resources = await robotClient.resourceNames();
@@ -112,14 +114,14 @@ function App() {
         return {
           start: new Date(pass.start),
           end: new Date(pass.end),
-          steps: pass.steps.map((x: any) => ({
+          steps: pass.steps ? pass.steps.map((x: any) => ({
             name: x.name!,
             start: new Date(x.start),
             end: new Date(x.end),
             // duration_ms: duration(x.start, x.end),
-          })),
+          })): [],
           success: pass.success ?? true,
-          pass_id: pass.pass_id || "N/A",
+          pass_id: pass.pass_id,
           // duration_ms: duration(pass.start, pass.end),
           err_string: pass.err_string  || null
         };
@@ -164,6 +166,7 @@ function App() {
 
   return (
     <AppInterface 
+      viamClient={viamClient!}
       passSummaries={passSummaries} // Pass the actual summaries
       // videoFiles={videoFiles}
       files={files}

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -11,6 +11,7 @@ import {
 interface AppViewProps {
   passSummaries?: any[];
   files: VIAM.dataApi.BinaryData[];
+  viamClient: VIAM.ViamClient;
   videoStoreClient?: VIAM.GenericComponentClient | null;
   // sanderClient: VIAM.GenericComponentClient | null;
   robotClient?: VIAM.RobotClient | null;
@@ -35,6 +36,7 @@ export interface Pass {
 
 
 const AppInterface: React.FC<AppViewProps> = ({ 
+  viamClient,
   passSummaries = [],
   files: files, 
   // sanderClient, 
@@ -47,6 +49,7 @@ const AppInterface: React.FC<AppViewProps> = ({
   const [selectedVideo, setSelectedVideo] = useState<VIAM.dataApi.BinaryData | null>(null);
   const [modalVideoUrl, setModalVideoUrl] = useState<string | null>(null);
   const [loadingModalVideo, setLoadingModalVideo] = useState(false);
+  const [downloadingFiles, setDownloadingFiles] = useState<Set<string>>(new Set());
   const filesByID = files.reduce((acc: any, file: VIAM.dataApi.BinaryData) => {
     acc[file.metadata!.binaryDataId] = file;
     return acc;
@@ -152,6 +155,47 @@ const AppInterface: React.FC<AppViewProps> = ({
     setModalVideoUrl(null);
   };
 
+  const handleDownload = async (file: VIAM.dataApi.BinaryData) => {
+    if (!file.metadata?.binaryDataId) return;
+    
+    const fileId = file.metadata.binaryDataId;
+    
+    // Set loading state
+    setDownloadingFiles(prev => new Set(prev).add(fileId));
+    
+    try {
+      const binaryData = await viamClient.dataClient.binaryDataByIds([fileId]);
+      if (binaryData.length > 0) {
+        const fileData = binaryData[0];
+        
+        // Create a File object with the desired filename
+        const fileObj = new File([fileData.binary], fileData.metadata?.fileName!, { 
+          type: fileData.metadata?.fileExt || 'application/octet-stream' 
+        });
+        
+        // Create object URL from the File
+        const url = URL.createObjectURL(fileObj);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = fileData.metadata?.fileName!;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
+    } catch (error) {
+      console.error('Download failed:', error);
+    } finally {
+      // Clear loading state
+      setDownloadingFiles(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(fileId);
+        return newSet;
+      });
+    }
+  }
+
   // Cleanup on unmount
   useEffect(() => {
     return () => {
@@ -163,6 +207,14 @@ const AppInterface: React.FC<AppViewProps> = ({
 
   return (
     <div className="appInterface">
+      <style>
+        {`
+          @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+          }
+        `}
+      </style>
       <header className="flex items-center sticky top-0 z-10 mb-4 px-4 py-3 border-b bg-zinc-50 shadow-none md:shadow-xs">
         <div className="w-1/3 h-5 font-semibold text-zinc-900">Sanding Control Interface</div>
         
@@ -370,11 +422,6 @@ const AppInterface: React.FC<AppViewProps> = ({
                                                   cursor: 'pointer',
                                                   transition: 'all 0.2s ease'
                                                 }}
-                                                onClick={() => {
-                                                  if (file.metadata?.uri) {
-                                                    window.open(file.metadata.uri, '_blank');
-                                                  }
-                                                }}
                                                 onMouseEnter={(e) => {
                                                   e.currentTarget.style.backgroundColor = '#e5e7eb';
                                                   e.currentTarget.style.transform = 'translateY(-1px)';
@@ -401,30 +448,53 @@ const AppInterface: React.FC<AppViewProps> = ({
                                                     {file.metadata?.timeRequested?.toDate().toLocaleTimeString() || ''}
                                                   </span>
                                                 </div>
-                                                <a 
-                                                  href={file.metadata?.uri}
-                                                  target="_blank"
-                                                  rel="noopener noreferrer"
+                                                <button 
                                                   style={{
                                                     marginLeft: '12px',
                                                     padding: '4px 12px',
-                                                    backgroundColor: '#3b82f6',
+                                                    backgroundColor: downloadingFiles.has(file.metadata?.binaryDataId || '') ? '#9ca3af' : '#3b82f6',
                                                     color: 'white',
                                                     borderRadius: '4px',
                                                     textDecoration: 'none',
                                                     fontSize: '12px',
                                                     whiteSpace: 'nowrap',
                                                     transition: 'background-color 0.2s',
-                                                    flexShrink: 0
+                                                    flexShrink: 0,
+                                                    cursor: downloadingFiles.has(file.metadata?.binaryDataId || '') ? 'not-allowed' : 'pointer'
                                                   }}
-                                                  onClick={(e) => {
+                                                  onClick={async (e) => {
+                                                    if (downloadingFiles.has(file.metadata?.binaryDataId || '')) return;
+                                                    await handleDownload(file);
                                                     e.stopPropagation();
                                                   }}
-                                                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#2563eb'}
-                                                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#3b82f6'}
+                                                  onMouseEnter={(e) => {
+                                                    if (!downloadingFiles.has(file.metadata?.binaryDataId || '')) {
+                                                      e.currentTarget.style.backgroundColor = '#2563eb';
+                                                    }
+                                                  }}
+                                                  onMouseLeave={(e) => {
+                                                    if (!downloadingFiles.has(file.metadata?.binaryDataId || '')) {
+                                                      e.currentTarget.style.backgroundColor = '#3b82f6';
+                                                    }
+                                                  }}
                                                 >
-                                                  Download
-                                                </a>
+                                                  {downloadingFiles.has(file.metadata?.binaryDataId || '') ? (
+                                                    <span style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                                                      <span style={{ 
+                                                        display: 'inline-block',
+                                                        width: '12px',
+                                                        height: '12px',
+                                                        border: '2px solid transparent',
+                                                        borderTop: '2px solid white',
+                                                        borderRadius: '50%',
+                                                        animation: 'spin 1s linear infinite'
+                                                      }}></span>
+                                                      Processing...
+                                                    </span>
+                                                  ) : (
+                                                    'Download'
+                                                  )}
+                                                </button>
                                               </div>
                                             );
                                           })}


### PR DESCRIPTION
Hey yall, this pr changes the webapp to download files as PCDs or .plys. It does this based on the file name. This is currently working around an app bug where I cannot specify the content type to app. 
The high level approach is:
1. Make a binaryDataByID call to get the actual data contained in the file that was requested for download
2. Turn that into a temporary file and name that according the file name
3. Download

This is slightly slower than the old approach but I think for usability, its overall faster than having to rename each file to the correct type to use it. 