### PR TITLE
Consult-1554 Add Notes System for Sanding Passes

### DIFF
--- a/changes.diff
+++ b/changes.diff
@@ -1,0 +1,658 @@
+diff --git a/src/App.tsx b/src/App.tsx
+index 30a3154..2c9d8b1 100644
+--- a/src/App.tsx
++++ b/src/App.tsx
+@@ -4,7 +4,7 @@ import AppInterface from './AppInterface';
+ import Cookies from "js-cookie";
+ import { JsonValue } from '@viamrobotics/sdk';
+ import { Pass } from './AppInterface';
+-import { createNotesManager, PassNote } from './lib/notesManager';
++import { PassNote } from './lib/notesManager';
+ 
+ // const videoStoreName = "video-store-1";
+ // const sanderName = "sander-module";
+@@ -162,20 +162,6 @@ function App() {
+ 
+       setPassSummaries(processedPasses);
+ 
+-      // Fetch all notes for all passes at once
+-      if (processedPasses.length > 0 && extractedPartId) {
+-        console.log("Fetching notes for all passes...");
+-        try {
+-          const notesManager = createNotesManager(viamClient, machineId);
+-          const passIds = processedPasses.map(pass => pass.pass_id).filter(Boolean);
+-          const allNotes = await notesManager.fetchNotesForPasses(passIds);
+-          setPassNotes(allNotes);
+-          console.log("Fetched notes for", passIds.length, "passes");
+-        } catch (error) {
+-          console.error("Failed to fetch notes:", error);
+-        }
+-      }
+-
+       let allFiles = [];
+       let last = undefined;
+       const earliestPassTime = new Date(Math.min(...processedPasses.map(p => p.start.getTime())));
+diff --git a/src/AppInterface.tsx b/src/AppInterface.tsx
+index 5ef6c34..24e3c47 100644
+--- a/src/AppInterface.tsx
++++ b/src/AppInterface.tsx
+@@ -7,7 +7,7 @@ import PassNotes from './PassNotes';
+ import { 
+   formatDurationToMinutesSeconds,
+ } from './lib/videoUtils';
+-import { PassNote } from './lib/notesManager';
++import { PassNote, createNotesManager } from './lib/notesManager';
+ 
+ interface AppViewProps {
+   passSummaries?: any[];
+@@ -56,6 +56,7 @@ const AppInterface: React.FC<AppViewProps> = ({
+   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+   const [downloadingFiles, setDownloadingFiles] = useState<Set<string>>(new Set());
+   const [videoStoreClient, setVideoStoreClient] = useState<VIAM.GenericComponentClient | null>(null);
++  const [loadingNotes, setLoadingNotes] = useState<Set<string>>(new Set());
+ 
+   // Filter files to only include video files (.mp4)
+   const videoFiles = files.filter((file: VIAM.dataApi.BinaryData) => 
+@@ -83,10 +84,45 @@ const AppInterface: React.FC<AppViewProps> = ({
+       newExpandedRows.delete(index);
+     } else {
+       newExpandedRows.add(index);
++      
++      // Load notes for this pass when expanding
++      const pass = passSummaries[index];
++      if (pass && pass.pass_id) {
++        loadNotesForPass(pass.pass_id);
++      }
+     }
+     setExpandedRows(newExpandedRows);
+   };
+ 
++  const loadNotesForPass = async (passId: string) => {
++    // Don't load if already loading or already have notes
++    if (loadingNotes.has(passId) || passNotes.has(passId)) {
++      return;
++    }
++    
++    setLoadingNotes(prev => new Set(prev).add(passId));
++    
++    try {
++      const notesManager = createNotesManager(viamClient, machineId);
++      const notes = await notesManager.fetchPassNotes(passId);
++      
++      // Update only the notes for this specific pass
++      onNotesUpdate((prevNotes) => {
++        const newNotes = new Map(prevNotes);
++        newNotes.set(passId, notes);
++        return newNotes;
++      });
++    } catch (error) {
++      console.error(`Failed to load notes for pass ${passId}:`, error);
++    } finally {
++      setLoadingNotes(prev => {
++        const newSet = new Set(prev);
++        newSet.delete(passId);
++        return newSet;
++      });
++    }
++  };
++
+   const getStepVideos = (step: Step) => {
+     if (!videoFiles) return [];
+ 
+@@ -495,6 +531,7 @@ const AppInterface: React.FC<AppViewProps> = ({
+                                             machineId={machineId}
+                                             partId={partId}
+                                             initialNotes={passNotes.get(pass.pass_id) || []}
++                                            isLoading={loadingNotes.has(pass.pass_id)}
+                                             onNotesUpdate={onNotesUpdate}
+                                           />
+                                         </div>
+diff --git a/src/PassNotes.tsx b/src/PassNotes.tsx
+index d0c33db..ab16a69 100644
+--- a/src/PassNotes.tsx
++++ b/src/PassNotes.tsx
+@@ -2,22 +2,24 @@ import React, { useState, useEffect } from 'react';
+ import * as VIAM from "@viamrobotics/sdk";
+ import { createNotesManager, PassNote } from './lib/notesManager';
+ 
+-interface PassNotesProps {
++export interface PassNotesProps {
+   passId: string;
+   viamClient: VIAM.ViamClient;
+   machineId: string;
+   partId: string;
+   initialNotes: PassNote[];
+-  onNotesUpdate: (updater: (prevNotes: Map<string, PassNote[]>) => Map<string, PassNote[]>) => void;
++  isLoading: boolean;
++  onNotesUpdate: React.Dispatch<React.SetStateAction<Map<string, PassNote[]>>>;
+ }
+ 
+-const PassNotes: React.FC<PassNotesProps> = ({ 
+-  passId, 
+-  viamClient, 
+-  machineId, 
+-  partId, 
++const PassNotes: React.FC<PassNotesProps> = ({
++  passId,
++  viamClient,
++  machineId,
++  partId,
+   initialNotes,
+-  onNotesUpdate 
++  isLoading,
++  onNotesUpdate,
+ }) => {
+   const [noteText, setNoteText] = useState<string>('');
+   const [originalNoteText, setOriginalNoteText] = useState<string>('');
+@@ -28,6 +30,7 @@ const PassNotes: React.FC<PassNotesProps> = ({
+   const notesManager = createNotesManager(viamClient, machineId);
+ 
+   useEffect(() => {
++    // If we have initial notes, use them
+     if (initialNotes.length > 0) {
+       const sortedNotes = [...initialNotes].sort((a, b) => 
+         new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+@@ -36,37 +39,38 @@ const PassNotes: React.FC<PassNotesProps> = ({
+       setNoteText(latestNoteText);
+       setOriginalNoteText(latestNoteText);
+     } else {
++      // Don't fetch here - let AppInterface handle it
+       setNoteText('');
+       setOriginalNoteText('');
+     }
+-  }, [initialNotes]);
++  }, [passId, initialNotes]); // Add initialNotes to dependencies
+ 
+   const saveNote = async () => {
++    if (saving) return; // Prevent double-clicks
++    
+     setSaving(true);
+     setError(null);
+-    setShowSuccess(false);
++    setShowSuccess(false); // Reset success state
+     
+     try {
+       const noteToSave = noteText.trim();
+-      await notesManager.savePassNote(passId, noteToSave, partId);
+       
+-      setOriginalNoteText(noteToSave);
++      // Get the created note directly from the savePassNote function
++      const newNote = await notesManager.savePassNote(passId, noteToSave, partId);
++      console.log("UI received saved note confirmation"); // Add this for debugging
+       
+-      const newNote: PassNote = {
+-        pass_id: passId,
+-        note_text: noteToSave,
+-        created_at: new Date().toISOString(),
+-        created_by: "web-app"
+-      };
++      // Update UI state with the returned note object
++      setOriginalNoteText(noteToSave);
+       
+-      onNotesUpdate((prevNotes: Map<string, PassNote[]>) => {
+-        const newNotesMap = new Map(prevNotes);
+-        const existingNotes = newNotesMap.get(passId) || [];
+-        const updatedNotes = [newNote, ...existingNotes];
+-        newNotesMap.set(passId, updatedNotes);
+-        return newNotesMap;
++      // Update the notes collection with the new note
++      onNotesUpdate((prevNotes) => {
++        const newMap = new Map(prevNotes);
++        const currentNotes = newMap.get(passId) || [];
++        newMap.set(passId, [newNote, ...currentNotes]);
++        return newMap;
+       });
+       
++      // Show success state
+       setShowSuccess(true);
+       setTimeout(() => setShowSuccess(false), 2000);
+       
+@@ -74,6 +78,7 @@ const PassNotes: React.FC<PassNotesProps> = ({
+       console.error("Error saving note:", err);
+       setError("Failed to save note");
+     } finally {
++      // Ensure this runs even if there's an error
+       setSaving(false);
+     }
+   };
+@@ -87,7 +92,7 @@ const PassNotes: React.FC<PassNotesProps> = ({
+       return (
+         <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+           <span style={{ 
+-            display: 'inline-block',
++            display: 'block',
+             width: '12px',
+             height: '12px',
+             border: '2px solid transparent',
+@@ -109,99 +114,99 @@ const PassNotes: React.FC<PassNotesProps> = ({
+   };
+ 
+   return (
+-    <div className="pass-notes-section" style={{
+-      height: '100%',
+-      display: 'flex',
+-      flexDirection: 'column'
+-    }}>
++    <div className="pass-notes-container">
+       <h4 style={{
+-        margin: '0 0 12px 0',
+-        fontSize: '14px',
+-        fontWeight: '600',
+-        color: '#1f2937'
++        position: 'sticky',
++        top: 0,
++        backgroundColor: '#fafafa',
++        zIndex: 1,
++        margin: 0,
++        padding: '0 0 8px 4px',
+       }}>
+         Notes for this pass
+       </h4>
+-
+-      <div style={{ 
+-        display: 'flex',
+-        flexDirection: 'column',
+-        flex: 1,
+-        minHeight: '120px'
+-      }}>
+-        <textarea
+-          id={`pass-notes-${passId}`}
+-          value={noteText}
+-          onChange={(e) => setNoteText(e.target.value)}
+-          placeholder="Add notes about this sanding pass..."
+-          style={{
+-            flexGrow: 1,
+-            width: '100%',
+-            padding: '12px',
+-            border: '1px solid #d1d5db',
+-            borderRadius: '6px',
+-            fontSize: '14px',
+-            fontFamily: 'inherit',
+-            resize: 'vertical',
+-            outline: 'none',
+-            boxSizing: 'border-box',
+-            marginBottom: '8px'
+-          }}
+-          onFocus={(e) => {
+-            e.target.style.borderColor = '#3b82f6';
+-            e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
+-          }}
+-          onBlur={(e) => {
+-            e.target.style.borderColor = '#d1d5db';
+-            e.target.style.boxShadow = 'none';
+-          }}
+-        />
+-        
+-        <div style={{ 
+-          display: 'flex', 
+-          justifyContent: 'space-between', 
+-          alignItems: 'center'
+-        }}>
++      {isLoading && (
++        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', padding: '20px' }}>
++          <div style={{ 
++            display: 'inline-block',
++            width: '24px',
++            height: '24px',
++            border: '3px solid rgba(0,0,0,0.1)',
++            borderTop: '3px solid #3b82f6',
++            borderRadius: '50%',
++            animation: 'spin 1s linear infinite'
++          }}></div>
++          <span style={{ marginLeft: '10px', color: '#6b7280' }}>Loading notes...</span>
++        </div>
++      )}
++      {!isLoading && (
++        <>
++          <textarea
++            value={noteText}
++            onChange={(e) => setNoteText(e.target.value)}
++            placeholder="Add notes about this pass..."
++            style={{
++              width: '100%',
++              height: '100px',
++              padding: '10px',
++              border: '1px solid #d1d5db',
++              borderRadius: '6px',
++              fontSize: '14px',
++              fontFamily: 'inherit',
++              resize: 'none',
++              outline: 'none',
++              transition: 'border-color 0.2s',
++            }}
++            onFocus={(e) => {
++              e.target.style.borderColor = '#3b82f6';
++            }}
++            onBlur={(e) => {
++              e.target.style.borderColor = '#d1d5db';
++            }}
++            disabled={saving}
++          />
++          
++          {/* Error message */}
+           {error && (
+-            <span style={{ color: '#dc2626', fontSize: '13px' }}>
++            <div style={{
++              marginTop: '8px',
++              padding: '8px 12px',
++              backgroundColor: '#fee2e2',
++              color: '#991b1b',
++              borderRadius: '4px',
++              fontSize: '13px'
++            }}>
+               {error}
+-            </span>
++            </div>
+           )}
+-          <div style={{ marginLeft: 'auto' }}>
+-            <button
+-              onClick={saveNote}
+-              disabled={saving || !canSave || showSuccess}
+-              style={{
+-                padding: '6px 12px',
+-                backgroundColor: getButtonColor(),
+-                color: 'white',
+-                border: 'none',
+-                borderRadius: '4px',
+-                fontSize: '12px',
+-                fontWeight: '500',
+-                cursor: saving || !canSave || showSuccess ? 'not-allowed' : 'pointer',
+-                transition: 'all 0.2s ease',
+-                whiteSpace: 'nowrap',
+-                lineHeight: '1.4'
+-              }}
+-              onMouseEnter={(e) => {
+-                if (canSave && !saving && !showSuccess) {
+-                  e.currentTarget.style.backgroundColor = '#2563eb';
+-                  e.currentTarget.style.transform = 'translateY(-1px)';
+-                }
+-              }}
+-              onMouseLeave={(e) => {
+-                if (canSave && !saving && !showSuccess) {
+-                  e.currentTarget.style.backgroundColor = '#3b82f6';
+-                  e.currentTarget.style.transform = 'translateY(0)';
+-                }
+-              }}
+-            >
+-              {getButtonText()}
+-            </button>
+-          </div>
+-        </div>
+-      </div>
++          
++          {/* Save button */}
++          <button
++            onClick={saveNote}
++            disabled={!canSave || saving}
++            style={{
++              marginTop: '12px',
++              padding: '10px 16px',
++              backgroundColor: getButtonColor(),
++              color: 'white',
++              border: 'none',
++              borderRadius: '6px',
++              fontSize: '14px',
++              fontWeight: '500',
++              cursor: canSave && !saving ? 'pointer' : 'not-allowed',
++              opacity: canSave && !saving ? 1 : 0.5,
++              transition: 'all 0.2s',
++              display: 'flex',
++              alignItems: 'center',
++              justifyContent: 'center',
++              gap: '6px',
++              width: '100px'
++            }}
++          >
++            {getButtonText()}
++          </button>
++        </>
++      )}
+     </div>
+   );
+ };
+diff --git a/src/lib/notesManager.ts b/src/lib/notesManager.ts
+index 53c5ab9..59c4e43 100644
+--- a/src/lib/notesManager.ts
++++ b/src/lib/notesManager.ts
+@@ -19,7 +19,7 @@ export class NotesManager {
+   /**
+    * Save a note for a specific pass
+    */
+-  async savePassNote(passId: string, noteText: string, partId: string): Promise<void> {
++  async savePassNote(passId: string, noteText: string, partId: string): Promise<PassNote> {
+     if (!this.viamClient) {
+       throw new Error("Viam client not initialized");
+     }
+@@ -43,138 +43,134 @@ export class NotesManager {
+     const noteJson = JSON.stringify(noteData);
+     const binaryData = new TextEncoder().encode(noteJson);
+ 
+-    // Upload the note as binary data
+-    await this.viamClient.dataClient.binaryDataCaptureUpload(
+-      binaryData,                     // binary data
+-      partId,                         // partId
+-      "rdk:component:generic",        // componentType
+-      "sanding-notes",                // componentName
+-      "SaveNote",                     // methodName
+-      ".json",                        // fileExtension
+-      [now, now],                     // methodParameters (start and end time)
+-      ["sanding-notes"]               // tags
+-    );
+-
+-    console.log("Note saved successfully!");
++    try {
++      // Upload the new note with pass_id in tags for easier filtering
++      await this.viamClient.dataClient.binaryDataCaptureUpload(
++        binaryData,
++        partId,
++        "rdk:component:generic",
++        "sanding-notes",
++        "SaveNote",
++        ".json",
++        [now, now],
++        ["sanding-notes", `pass:${passId}`] // Add pass ID as a tag
++      );
++
++      console.log("Note saved successfully!");
++
++      // Run cleanup asynchronously - don't wait for it
++      this.deleteOldNotes(passId)
++        .then(() => console.log("Background cleanup completed"))
++        .catch(error => console.warn("Background cleanup failed:", error));
++
++      // Return immediately so UI can update
++      return noteData;
++    } catch (error) {
++      console.error("Failed to save note:", error);
++      throw error;
++    }
+   }
+ 
+   /**
+-   * Fetch all notes for a specific pass
++   * Delete old notes for a pass, keeping only the most recent one
+    */
+-  async fetchPassNotes(passId: string): Promise<PassNote[]> {
+-    if (!this.viamClient) {
+-      throw new Error("Viam client not initialized");
+-    }
+-
+-    // Use correct filter properties and cast to unknown first
+-    const filter = {
+-      robotId: this.machineId,
+-      componentName: "sanding-notes",
+-      componentType: "rdk:component:generic",
+-      tags: ["sanding-notes"]
+-    } as unknown as VIAM.dataApi.Filter;
+-
+-    const binaryData = await this.viamClient.dataClient.binaryDataByFilter(
+-      filter,
+-      100, // limit
+-      VIAM.dataApi.Order.DESCENDING,
+-      undefined, // no pagination token
+-      false,
+-      false,
+-      false
+-    );
+-
+-    // Filter and parse notes for this specific pass
+-    const passNotes: PassNote[] = [];
+-    for (const item of binaryData.data) {
+-      try {
+-        // Use binaryDataByIds to get the actual binary data
+-        const noteDataArray = await this.viamClient.dataClient.binaryDataByIds([item.metadata!.binaryDataId!]);
+-        if (noteDataArray.length > 0) {
+-          // Properly access binary data from the response
+-          const binaryDataItem = noteDataArray[0];
+-          let noteBytes: Uint8Array;
+-
+-          if (binaryDataItem.binary) {
+-            noteBytes = binaryDataItem.binary;
+-          } else {
+-            console.warn("No binary data found in response");
+-            continue;
+-          }
+-
+-          const noteJson = new TextDecoder().decode(noteBytes);
++  async deleteOldNotes(passId: string): Promise<void> {
++    try {
++      const filter = {
++        robotId: this.machineId,
++        componentName: "sanding-notes",
++        componentType: "rdk:component:generic",
++        tags: ["sanding-notes"]
++      } as unknown as VIAM.dataApi.Filter;
++
++      const binaryData = await this.viamClient.dataClient.binaryDataByFilter(
++        filter,
++        20, // Limit - we only need recent notes
++        VIAM.dataApi.Order.DESCENDING,
++        undefined,
++        false,
++        false,
++        true // Include binary data!
++      );
++
++      // Collect notes for this pass
++      const notesForPass: Array<{
++        note: PassNote,
++        binaryId: string,
++        createdAt: Date
++      }> = [];
++
++      for (const item of binaryData.data) {
++        if (!item.metadata?.binaryDataId || !item.binary) continue;
++
++        try {
++          const noteJson = new TextDecoder().decode(item.binary);
+           const noteData = JSON.parse(noteJson) as PassNote;
+ 
+           if (noteData.pass_id === passId) {
+-            passNotes.push(noteData);
++            notesForPass.push({
++              note: noteData,
++              binaryId: item.metadata.binaryDataId,
++              createdAt: new Date(noteData.created_at)
++            });
+           }
++        } catch (error) {
++          console.warn("Failed to process note:", error);
+         }
+-      } catch (parseError) {
+-        console.warn("Failed to parse note data:", parseError);
+       }
+-    }
+ 
+-    console.log("Retrieved notes:", passNotes);
+-    return passNotes;
++      // Delete old notes if more than 1
++      if (notesForPass.length > 1) {
++        notesForPass.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
++        const idsToDelete = notesForPass.slice(1).map(item => item.binaryId);
++
++        console.log(`Cleaning up ${idsToDelete.length} old notes for pass ${passId}`);
++
++        if (idsToDelete.length > 0) {
++          await this.viamClient.dataClient.deleteBinaryDataByIds(idsToDelete);
++        }
++      }
++    } catch (error) {
++      console.error("Failed to clean up old notes:", error);
++    }
+   }
+ 
+   /**
+-   * Fetch notes for multiple passes
++   * Fetch all notes for a specific pass
+    */
+-  async fetchNotesForPasses(passIds: string[]): Promise<Map<string, PassNote[]>> {
++  async fetchPassNotes(passId: string): Promise<PassNote[]> {
+     if (!this.viamClient) {
+       throw new Error("Viam client not initialized");
+     }
+ 
++    console.log(`Fetching notes for pass ${passId}`);
++    const startTime = Date.now();
++
+     const filter = {
+       robotId: this.machineId,
+       componentName: "sanding-notes",
+       componentType: "rdk:component:generic",
+-      tags: ["sanding-notes"]
++      tags: [`pass:${passId}`] // Use the specific tag for faster filtering
+     } as unknown as VIAM.dataApi.Filter;
+ 
+     const binaryData = await this.viamClient.dataClient.binaryDataByFilter(
+       filter,
+-      500, // higher limit for multiple passes
++      20,
+       VIAM.dataApi.Order.DESCENDING,
+       undefined,
+       false,
+       false,
+-      false
++      true // Keep this to include binary data in one call
+     );
+ 
+-    const notesByPassId = new Map<string, PassNote[]>();
+-
+-    // Initialize empty arrays for all requested pass IDs
+-    passIds.forEach(passId => {
+-      notesByPassId.set(passId, []);
+-    });
+-
+-    // Parse and organize notes by pass ID
+-    for (const item of binaryData.data) {
+-      try {
+-        const noteDataArray = await this.viamClient.dataClient.binaryDataByIds([item.metadata!.binaryDataId!]);
+-        if (noteDataArray.length > 0) {
+-          const binaryDataItem = noteDataArray[0];
+-
+-          if (binaryDataItem.binary) {
+-            const noteJson = new TextDecoder().decode(binaryDataItem.binary);
+-            const noteData = JSON.parse(noteJson) as PassNote;
+-
+-            // Only include notes for requested pass IDs
+-            if (passIds.includes(noteData.pass_id)) {
+-              const existingNotes = notesByPassId.get(noteData.pass_id) || [];
+-              existingNotes.push(noteData);
+-              notesByPassId.set(noteData.pass_id, existingNotes);
+-            }
+-          }
+-        }
+-      } catch (parseError) {
+-        console.warn("Failed to parse note data:", parseError);
+-      }
+-    }
++    // The rest of the function can be simplified as you no longer need to filter by pass_id in the loop
++    const passNotes: PassNote[] = binaryData.data.map(item => {
++      const noteJson = new TextDecoder().decode(item.binary!);
++      return JSON.parse(noteJson) as PassNote;
++    }).sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+ 
+-    return notesByPassId;
++    console.log(`Retrieved ${passNotes.length} notes in ${Date.now() - startTime}ms`);
++    return passNotes;
+   }
+ 
+   /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,17 +6,6 @@ import { JsonValue } from '@viamrobotics/sdk';
 import { Pass } from './AppInterface';
 import { createNotesManager, PassNote } from './lib/notesManager';
 
-/*
-TODO:
-- detect if there is a sanding resource
-    - if so show a button to start sanding
-    - if not, show a warning that there is no sanding resource
-- detect if there is a video-store resource
-    - if so show request a video from the past 1 minute and show the video
-- add pagination
-
-*/
-
 // const videoStoreName = "video-store-1";
 // const sanderName = "sander-module";
 const sandingSummaryName = "sanding-summary";
@@ -232,8 +221,8 @@ function App() {
       fetchVideos={fetchVideos}
       machineId={machineId}
       partId={partId}
-      passNotes={passNotes} // Pass the notes to AppInterface
-      onNotesUpdate={setPassNotes} // Pass update function
+      passNotes={passNotes}
+      onNotesUpdate={setPassNotes}
     />
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import AppInterface from './AppInterface';
 import Cookies from "js-cookie";
 import { JsonValue } from '@viamrobotics/sdk';
 import { Pass } from './AppInterface';
-import { createNotesManager } from './lib/notesManager';
 
 /*
 TODO:
@@ -33,9 +32,8 @@ function App() {
   const [passSummaries, setPassSummaries] = useState<Pass[]>([]);
   const [files, setFiles] = useState<VIAM.dataApi.BinaryData[]>([]);
   const [viamClient, setViamClient] = useState<VIAM.ViamClient | null>(null);
-  // const [sanderClient, setSanderClient] = useState<VIAM.GenericComponentClient | null>(null);
   const [robotClient, setRobotClient] = useState<VIAM.RobotClient | null>(null);
-  // const [sanderWarning, setSanderWarning] = useState<string | null>(null); // Warning state
+  const [partId, setPartId] = useState<string>(''); // Add partId state
 
   const machineNameMatch = window.location.pathname.match(machineNameRegex);
   const machineName = machineNameMatch ? machineNameMatch[1] : null;
@@ -146,28 +144,10 @@ function App() {
       const tabularData = await viamClient.dataClient.tabularDataByMQL(orgID, mqlQuery);
       console.log("Tabular Data:", tabularData);
 
-      // Test the new NotesManager
+      // Set partId in state
       if (tabularData && tabularData.length > 0) {
-        const firstPass = (tabularData[0] as any).data?.readings?.pass_id;
-        const partId = (tabularData[0] as any).part_id;
-        
-        if (firstPass && partId) {
-          console.log(`Found pass ID for testing: ${firstPass}`);
-          
-          // Create NotesManager instance
-          const notesManager = createNotesManager(viamClient, machineId);
-          
-          try {
-            // Test saving a note
-            await notesManager.savePassNote(firstPass, "This is a test note created at " + new Date().toLocaleString(), partId);
-            
-            // Test retrieving the note
-            const notes = await notesManager.fetchPassNotes(firstPass);
-            console.log("Retrieved test notes:", notes);
-          } catch (error) {
-            console.error("Failed to test notes functionality:", error);
-          }
-        }
+        const extractedPartId = (tabularData[0] as any).part_id;
+        setPartId(extractedPartId || '');
       }
     
       // Process tabular data into pass summaries
@@ -228,17 +208,14 @@ function App() {
 
   return (
     <AppInterface 
-
-
       machineName={machineName}
-
       viamClient={viamClient!}
-      passSummaries={passSummaries} // Pass the actual summaries
+      passSummaries={passSummaries}      
       files={files}
       robotClient={robotClient}
-      // sanderClient={null}
-      // sanderWarning={sanderWarning} // Pass the sanding warning
       fetchVideos={fetchVideos}
+      machineId={machineId}
+      partId={partId} // Now using the state variable
     />
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import AppInterface from './AppInterface';
 import Cookies from "js-cookie";
 import { JsonValue } from '@viamrobotics/sdk';
 import { Pass } from './AppInterface';
-import { createNotesManager, PassNote } from './lib/notesManager';
+import { PassNote } from './lib/notesManager';
 
 // const videoStoreName = "video-store-1";
 // const sanderName = "sander-module";
@@ -161,20 +161,6 @@ function App() {
       });
 
       setPassSummaries(processedPasses);
-
-      // Fetch all notes for all passes at once
-      if (processedPasses.length > 0 && extractedPartId) {
-        console.log("Fetching notes for all passes...");
-        try {
-          const notesManager = createNotesManager(viamClient, machineId);
-          const passIds = processedPasses.map(pass => pass.pass_id).filter(Boolean);
-          const allNotes = await notesManager.fetchNotesForPasses(passIds);
-          setPassNotes(allNotes);
-          console.log("Fetched notes for", passIds.length, "passes");
-        } catch (error) {
-          console.error("Failed to fetch notes:", error);
-        }
-      }
 
       let allFiles = [];
       let last = undefined;

--- a/src/AppInterface.css
+++ b/src/AppInterface.css
@@ -567,7 +567,7 @@ button:focus {
 .passes-container {
   display: flex;
   flex-direction: column;
-  padding: 4px;
+  padding: 8px;
   gap: 1rem;
 }
 
@@ -580,7 +580,13 @@ button:focus {
 }
 
 .pass-files-section {
-  margin: 0 5px;
+  overflow-y: auto;
+  max-height: 200px;
+  margin: 0 0 -7px;
+}
+
+.pass-files-section h4 {
+  margin: 0 0 4px 4px;
 }
 
 .steps-grid {

--- a/src/AppInterface.css
+++ b/src/AppInterface.css
@@ -567,7 +567,7 @@ button:focus {
 .passes-container {
   display: flex;
   flex-direction: column;
-  padding: 8px;
+  padding: 8px 12px;
   gap: 1rem;
 }
 
@@ -582,7 +582,6 @@ button:focus {
 .pass-files-section {
   overflow-y: auto;
   max-height: 200px;
-  margin: 0 0 -7px;
 }
 
 .pass-files-section h4 {
@@ -593,6 +592,10 @@ button:focus {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* Increased from 200px */
   gap: 12px;
+}
+
+.generate-video {
+  margin-top: 5px;
 }
 
 @media (max-width: 640px) {

--- a/src/AppInterface.css
+++ b/src/AppInterface.css
@@ -188,8 +188,8 @@ ol {
   background-color: rgb(250 250 250);
 }
 
-.bg-blue-600 {
-  background-color: rgb(37 99 235);
+.bg-black-900 {
+  background-color: rgba(0 0 0 / 0.9);
 }
 
 .bg-gray-200 {
@@ -590,7 +590,7 @@ button:focus {
 
 .steps-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); /* Increased from 200px */
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 12px;
 }
 

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -349,7 +349,7 @@ const AppInterface: React.FC<AppViewProps> = ({
                                         
                                         <div style={{ 
                                           display: 'flex',
-                                          flexWrap: 'wrap',
+                                          flexDirection: 'column',
                                           gap: '8px',
                                           overflowY: 'auto',
                                           padding: '4px'
@@ -371,9 +371,7 @@ const AppInterface: React.FC<AppViewProps> = ({
                                                   fontSize: '13px',
                                                   cursor: 'pointer',
                                                   transition: 'all 0.2s ease',
-                                                  flex: '1 0 calc(50% - 8px)',
-                                                  minWidth: '280px',
-                                                  maxWidth: 'calc(50% - 10px)',
+                                                  width: '100%',
                                                   boxSizing: 'border-box'
                                                 }}
                                                 onMouseEnter={(e) => {
@@ -385,7 +383,6 @@ const AppInterface: React.FC<AppViewProps> = ({
                                                   e.currentTarget.style.transform = 'translateY(0)';
                                                 }}
                                               >
-                                                {/* ...existing file display logic... */}
                                                 <div style={{ 
                                                   display: 'flex', 
                                                   alignItems: 'center', 
@@ -418,6 +415,7 @@ const AppInterface: React.FC<AppViewProps> = ({
                                                     padding: '4px 12px',
                                                     backgroundColor: downloadingFiles.has(file.metadata?.binaryDataId || '') ? '#9ca3af' : '#3b82f6',
                                                     color: 'white',
+                                                    border: 'none',
                                                     borderRadius: '4px',
                                                     textDecoration: 'none',
                                                     fontSize: '12px',
@@ -467,17 +465,36 @@ const AppInterface: React.FC<AppViewProps> = ({
                                     );
 
                                     return (
-                                      <>
-                                        {filesSection}
+                                      <div style={{
+                                        display: 'flex',
+                                        gap: '12px',
+                                        width: '100%',
+                                        maxWidth: '100%',
+                                        overflow: 'hidden'
+                                      }}>
+                                        {/* Files section - Left column - 50% width */}
+                                        <div style={{ 
+                                          flex: '1 1 calc(50% - 6px)',
+                                          minWidth: 0,
+                                          boxSizing: 'border-box'
+                                        }}>
+                                          {filesSection}
+                                        </div>
                                         
-                                        {/* New Notes section */}
-                                        <PassNotes
-                                          passId={pass.pass_id}
-                                          viamClient={viamClient}
-                                          machineId={machineId}
-                                          partId={partId}
-                                        />
-                                      </>
+                                        {/* Notes section - Right column - 50% width */}
+                                        <div style={{ 
+                                          flex: '1 1 calc(50% - 6px)',
+                                          minWidth: 0,
+                                          boxSizing: 'border-box'
+                                        }}>
+                                          <PassNotes
+                                            passId={pass.pass_id}
+                                            viamClient={viamClient}
+                                            machineId={machineId}
+                                            partId={partId}
+                                          />
+                                        </div>
+                                      </div>
                                     );
                                   })()}
                                 </div>

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -3,6 +3,7 @@ import * as VIAM from "@viamrobotics/sdk";
 import './AppInterface.css';
 import StepVideosGrid from './StepVideosGrid';
 import VideoStoreSelector from './VideoStoreSelector';
+import PassNotes from './PassNotes';
 import { 
   formatDurationToMinutesSeconds,
 } from './lib/videoUtils';
@@ -11,13 +12,11 @@ interface AppViewProps {
   passSummaries?: any[];
   files: VIAM.dataApi.BinaryData[];
   viamClient: VIAM.ViamClient;
-
-
-  // sanderClient: VIAM.GenericComponentClient | null;
   robotClient?: VIAM.RobotClient | null;
-  // sanderWarning?: string | null;
   fetchVideos: () => Promise<void>;
   machineName: string | null;
+  machineId: string; // Add machineId prop
+  partId: string; // Add partId prop
 }
 export interface Step {
   name: string;
@@ -39,16 +38,14 @@ export interface Pass {
 
 
 const AppInterface: React.FC<AppViewProps> = ({ 
-
   machineName,
   viamClient,
   passSummaries = [],
   files: files, 
-  // sanderClient, 
   robotClient,
-  // sanderWarning
-
   fetchVideos,
+  machineId, // Add machineId
+  partId, // Add partId
 }) => {
   const [activeRoute, setActiveRoute] = useState('live');
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
@@ -305,7 +302,7 @@ const AppInterface: React.FC<AppViewProps> = ({
                                     })}
                                   </div>
                                 
-                                  {/* New section for all files in pass time range */}
+                                  {/* Files section */}
                                   {(() => {
                                     const passStart = new Date(pass.start);
                                     const passEnd = new Date(pass.end);
@@ -331,21 +328,22 @@ const AppInterface: React.FC<AppViewProps> = ({
                                       return timeA - timeB;
                                     })
 
-                                    // Only render the section if there are files
-                                    if (passFiles.length === 0) {
-                                      return <div className="pass-files-section">
-                                        <h4>
-                                          Files captured during this pass
-                                        </h4>
-                                        <p>
-                                          No files found
-                                        </p>
-                                        </div>
-                                    }
-                                    
-                                    return (
+                                    // Files section (existing code)
+                                    const filesSection = passFiles.length === 0 ? (
                                       <div className="pass-files-section">
-                                        <h4>
+                                        <h4>Files captured during this pass</h4>
+                                        <p>No files found</p>
+                                      </div>
+                                    ) : (
+                                      <div className="pass-files-section">
+                                        <h4 style={{
+                                          position: 'sticky',
+                                          top: 0,
+                                          backgroundColor: '#fafafa',
+                                          zIndex: 1,
+                                          margin: 0,
+                                          padding: '0 0 8px 4px',
+                                        }}>
                                           Files captured during this pass
                                         </h4>
                                         
@@ -353,7 +351,6 @@ const AppInterface: React.FC<AppViewProps> = ({
                                           display: 'flex',
                                           flexWrap: 'wrap',
                                           gap: '8px',
-                                          maxHeight: '400px',
                                           overflowY: 'auto',
                                           padding: '4px'
                                         }}>
@@ -376,7 +373,7 @@ const AppInterface: React.FC<AppViewProps> = ({
                                                   transition: 'all 0.2s ease',
                                                   flex: '1 0 calc(50% - 8px)',
                                                   minWidth: '280px',
-                                                  maxWidth: '100%',
+                                                  maxWidth: 'calc(50% - 10px)',
                                                   boxSizing: 'border-box'
                                                 }}
                                                 onMouseEnter={(e) => {
@@ -388,6 +385,7 @@ const AppInterface: React.FC<AppViewProps> = ({
                                                   e.currentTarget.style.transform = 'translateY(0)';
                                                 }}
                                               >
+                                                {/* ...existing file display logic... */}
                                                 <div style={{ 
                                                   display: 'flex', 
                                                   alignItems: 'center', 
@@ -467,6 +465,20 @@ const AppInterface: React.FC<AppViewProps> = ({
                                         </div>
                                       </div>
                                     );
+
+                                    return (
+                                      <>
+                                        {filesSection}
+                                        
+                                        {/* New Notes section */}
+                                        <PassNotes
+                                          passId={pass.pass_id}
+                                          viamClient={viamClient}
+                                          machineId={machineId}
+                                          partId={partId}
+                                        />
+                                      </>
+                                    );
                                   })()}
                                 </div>
                               </div>
@@ -482,28 +494,8 @@ const AppInterface: React.FC<AppViewProps> = ({
           </>
         ) : (
           null
-          // <section>
-          //   {/* Add warning banner here, only in Robot Operator tab */}
-          //   {sanderWarning && (
-          //     <div className="warning-banner" style={{
-          //       backgroundColor: '#FEF3C7',
-          //       color: '#92400E',
-          //       padding: '12px 16px',
-          //       borderRadius: '8px',
-          //       display: 'flex',
-          //       alignItems: 'center',
-          //       gap: '8px',
-          //       marginBottom: '16px'
-          //     }}>
-          //       <span>⚠️</span>
-          //       <span>{sanderWarning}</span>
-          //     </div>
-          //   )}
-          //   <RobotOperator sanderClient={sanderClient} robotClient={robotClient} />
-          // </section>
         )}
       </main>
-      
     </div>
   );
 };

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -60,10 +60,10 @@ const AppInterface: React.FC<AppViewProps> = ({
     file.metadata?.fileName?.toLowerCase().endsWith('.mp4')
   );
 
-  const filesByID = files.reduce((acc: any, file: VIAM.dataApi.BinaryData) => {
-    acc[file.metadata!.binaryDataId] = file;
-    return acc;
-  }, {});
+  // const filesByID = files.reduce((acc: any, file: VIAM.dataApi.BinaryData) => {
+  //   acc[file.metadata!.binaryDataId] = file;
+  //   return acc;
+  // }, {});
 
   // const expectedSteps = [
   //   "Imaging",

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -74,7 +74,7 @@ const AppInterface: React.FC<AppViewProps> = ({
   //   "Executing"
   // ];
 
-  const activeTabStyle = "bg-blue-600 text-white";
+  const activeTabStyle = "bg-black-900 text-white";
   const inactiveTabStyle = "bg-gray-200 text-gray-700 hover:bg-gray-300";
 
   const toggleRowExpansion = (index: number) => {
@@ -333,7 +333,6 @@ const AppInterface: React.FC<AppViewProps> = ({
                                       return timeA - timeB;
                                     })
 
-                                    // Files section (existing code)
                                     const filesSection = passFiles.length === 0 ? (
                                       <div className="pass-files-section">
                                         <h4>Files captured during this pass</h4>

--- a/src/AppInterface.tsx
+++ b/src/AppInterface.tsx
@@ -7,6 +7,7 @@ import PassNotes from './PassNotes';
 import { 
   formatDurationToMinutesSeconds,
 } from './lib/videoUtils';
+import { PassNote } from './lib/notesManager';
 
 interface AppViewProps {
   passSummaries?: any[];
@@ -15,8 +16,10 @@ interface AppViewProps {
   robotClient?: VIAM.RobotClient | null;
   fetchVideos: () => Promise<void>;
   machineName: string | null;
-  machineId: string; // Add machineId prop
-  partId: string; // Add partId prop
+  machineId: string;
+  partId: string;
+  passNotes: Map<string, PassNote[]>;
+  onNotesUpdate: React.Dispatch<React.SetStateAction<Map<string, PassNote[]>>>;
 }
 export interface Step {
   name: string;
@@ -44,8 +47,10 @@ const AppInterface: React.FC<AppViewProps> = ({
   files: files, 
   robotClient,
   fetchVideos,
-  machineId, // Add machineId
-  partId, // Add partId
+  machineId,
+  partId,
+  passNotes,
+  onNotesUpdate,
 }) => {
   const [activeRoute, setActiveRoute] = useState('live');
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
@@ -472,7 +477,6 @@ const AppInterface: React.FC<AppViewProps> = ({
                                         maxWidth: '100%',
                                         overflow: 'hidden'
                                       }}>
-                                        {/* Files section - Left column - 50% width */}
                                         <div style={{ 
                                           flex: '1 1 calc(50% - 6px)',
                                           minWidth: 0,
@@ -481,7 +485,6 @@ const AppInterface: React.FC<AppViewProps> = ({
                                           {filesSection}
                                         </div>
                                         
-                                        {/* Notes section - Right column - 50% width */}
                                         <div style={{ 
                                           flex: '1 1 calc(50% - 6px)',
                                           minWidth: 0,
@@ -492,6 +495,8 @@ const AppInterface: React.FC<AppViewProps> = ({
                                             viamClient={viamClient}
                                             machineId={machineId}
                                             partId={partId}
+                                            initialNotes={passNotes.get(pass.pass_id) || []}
+                                            onNotesUpdate={onNotesUpdate}
                                           />
                                         </div>
                                       </div>

--- a/src/PassNotes.tsx
+++ b/src/PassNotes.tsx
@@ -1,70 +1,73 @@
 import React, { useState, useEffect } from 'react';
 import * as VIAM from "@viamrobotics/sdk";
-import { createNotesManager } from './lib/notesManager';
+import { createNotesManager, PassNote } from './lib/notesManager';
 
 interface PassNotesProps {
   passId: string;
   viamClient: VIAM.ViamClient;
   machineId: string;
   partId: string;
+  initialNotes: PassNote[]; // Add pre-fetched notes
+  onNotesUpdate: React.Dispatch<React.SetStateAction<Map<string, PassNote[]>>>; // Accept state setter style
 }
 
-const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, partId }) => {
+const PassNotes: React.FC<PassNotesProps> = ({ 
+  passId, 
+  viamClient, 
+  machineId, 
+  partId, 
+  initialNotes,
+  onNotesUpdate 
+}) => {
   const [noteText, setNoteText] = useState<string>('');
-  const [originalNoteText, setOriginalNoteText] = useState<string>(''); // Track original text
-  const [loading, setLoading] = useState<boolean>(true);
+  const [originalNoteText, setOriginalNoteText] = useState<string>('');
   const [saving, setSaving] = useState<boolean>(false);
-  const [showSuccess, setShowSuccess] = useState<boolean>(false); // Track success state
+  const [showSuccess, setShowSuccess] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
   const notesManager = createNotesManager(viamClient, machineId);
 
+  // Initialize with pre-fetched notes
   useEffect(() => {
-    const fetchNotes = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const notes = await notesManager.fetchPassNotes(passId);
-        
-        // Set the most recent note as the current text
-        if (notes.length > 0) {
-          const sortedNotes = notes.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
-          const latestNoteText = sortedNotes[0].note_text;
-          setNoteText(latestNoteText);
-          setOriginalNoteText(latestNoteText); // Track original text
-        } else {
-          setNoteText('');
-          setOriginalNoteText('');
-        }
-      } catch (err) {
-        console.error("Error fetching notes:", err);
-        setError("Failed to load notes");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (passId && viamClient && machineId) {
-      fetchNotes();
+    if (initialNotes.length > 0) {
+      const sortedNotes = [...initialNotes].sort((a, b) => 
+        new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      );
+      const latestNoteText = sortedNotes[0].note_text;
+      setNoteText(latestNoteText);
+      setOriginalNoteText(latestNoteText);
+    } else {
+      setNoteText('');
+      setOriginalNoteText('');
     }
-  }, [passId, viamClient, machineId]);
+  }, [initialNotes]);
 
   const saveNote = async () => {
-    if (!noteText.trim()) {
-      setError("Note cannot be empty");
-      return;
-    }
-
     setSaving(true);
     setError(null);
     setShowSuccess(false);
     
     try {
-      await notesManager.savePassNote(passId, noteText.trim(), partId);
-      console.log("Note saved successfully!");
+      // Allow empty notes - this acts as a "delete"
+      const noteToSave = noteText.trim();
+      await notesManager.savePassNote(passId, noteToSave, partId);
+      
+      if (noteToSave === '') {
+        console.log("Empty note saved - effectively deleting note for pass:", passId);
+      } else {
+        console.log("Note saved successfully!");
+      }
       
       // Update original text to current text
-      setOriginalNoteText(noteText.trim());
+      setOriginalNoteText(noteToSave);
+      
+      // Update the global notes state by fetching fresh notes for this pass
+      const updatedNotes = await notesManager.fetchPassNotes(passId);
+      onNotesUpdate((prevNotes: Map<string, PassNote[]>) => {
+        const newNotesMap = new Map(prevNotes);
+        newNotesMap.set(passId, updatedNotes);
+        return newNotesMap;
+      });
       
       // Show success state
       setShowSuccess(true);
@@ -82,9 +85,9 @@ const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, pa
     }
   };
 
-  // Check if there are changes
+  // Check if there are changes - now allows empty notes
   const hasChanges = noteText.trim() !== originalNoteText.trim();
-  const canSave = hasChanges && noteText.trim().length > 0;
+  const canSave = hasChanges; // Remove the requirement for non-empty text
 
   // Button styling based on state
   const getButtonStyle = () => {
@@ -100,7 +103,7 @@ const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, pa
       };
     } else if (canSave) {
       return {
-        backgroundColor: '#3b82f6', // Blue for enabled
+        backgroundColor: '#3b82f6', // Blue for save (always)
         cursor: 'pointer'
       };
     } else {
@@ -111,6 +114,7 @@ const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, pa
     }
   };
 
+  // Update button text to always show "Save note"
   const getButtonText = () => {
     if (showSuccess) {
       return 'Success';
@@ -149,86 +153,80 @@ const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, pa
         Notes for this pass
       </h4>
 
-      {loading ? (
-        <div style={{ padding: '16px', textAlign: 'center', color: '#6b7280' }}>
-          Loading notes...
-        </div>
-      ) : (
+      <div style={{ 
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: '120px'
+      }}>
+        <textarea
+          id={`pass-notes-${passId}`}
+          value={noteText}
+          onChange={(e) => setNoteText(e.target.value)}
+          placeholder="Add notes about this sanding pass..."
+          rows={4}
+          style={{
+            flexGrow: 1,
+            width: '100%',
+            padding: '12px',
+            border: '1px solid #d1d5db',
+            fontSize: '14px',
+            fontFamily: 'inherit',
+            resize: 'vertical',
+            outline: 'none',
+            boxSizing: 'border-box',
+            marginBottom: '8px'
+          }}
+          onFocus={(e) => {
+            e.target.style.borderColor = '#3b82f6';
+            e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
+          }}
+          onBlur={(e) => {
+            e.target.style.borderColor = '#d1d5db';
+            e.target.style.boxShadow = 'none';
+          }}
+        />
+        
         <div style={{ 
-          display: 'flex',
-          flexDirection: 'column',
-          flex: 1,
-          minHeight: '120px'
+          display: 'flex', 
+          justifyContent: 'space-between', 
+          alignItems: 'center'
         }}>
-          <textarea
-            id={`pass-notes-${passId}`}
-            value={noteText}
-            onChange={(e) => setNoteText(e.target.value)}
-            placeholder="Add notes about this sanding pass..."
-            rows={4}
-            style={{
-              flexGrow: 1,
-              width: '100%',
-              padding: '12px',
-              border: '1px solid #d1d5db',
-              fontSize: '14px',
-              fontFamily: 'inherit',
-              resize: 'vertical',
-              outline: 'none',
-              boxSizing: 'border-box',
-              marginBottom: '8px'
-            }}
-            onFocus={(e) => {
-              e.target.style.borderColor = '#3b82f6';
-              e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
-            }}
-            onBlur={(e) => {
-              e.target.style.borderColor = '#d1d5db';
-              e.target.style.boxShadow = 'none';
-            }}
-          />
-          
-          <div style={{ 
-            display: 'flex', 
-            justifyContent: 'space-between', 
-            alignItems: 'center'
-          }}>
-            {error && (
-              <span style={{ color: '#dc2626', fontSize: '13px' }}>
-                {error}
-              </span>
-            )}
-            <div style={{ marginLeft: 'auto' }}>
-              <button
-                onClick={saveNote}
-                disabled={saving || !canSave || showSuccess}
-                style={{
-                  padding: '8px 16px',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '6px',
-                  fontSize: '12px',
-                  transition: 'background-color 0.2s',
-                  whiteSpace: 'nowrap',
-                  ...getButtonStyle()
-                }}
-                onMouseEnter={(e) => {
-                  if (canSave && !saving && !showSuccess) {
-                    e.currentTarget.style.backgroundColor = '#2563eb';
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (canSave && !saving && !showSuccess) {
-                    e.currentTarget.style.backgroundColor = '#3b82f6';
-                  }
-                }}
-              >
-                {getButtonText()}
-              </button>
-            </div>
+          {error && (
+            <span style={{ color: '#dc2626', fontSize: '13px' }}>
+              {error}
+            </span>
+          )}
+          <div style={{ marginLeft: 'auto' }}>
+            <button
+              onClick={saveNote}
+              disabled={saving || !canSave || showSuccess}
+              style={{
+                padding: '8px 16px',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                fontSize: '12px',
+                transition: 'background-color 0.2s',
+                whiteSpace: 'nowrap',
+                ...getButtonStyle()
+              }}
+              onMouseEnter={(e) => {
+                if (canSave && !saving && !showSuccess) {
+                  e.currentTarget.style.backgroundColor = '#2563eb';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (canSave && !saving && !showSuccess) {
+                  e.currentTarget.style.backgroundColor = '#3b82f6';
+                }
+              }}
+            >
+              {getButtonText()}
+            </button>
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/src/PassNotes.tsx
+++ b/src/PassNotes.tsx
@@ -136,12 +136,12 @@ const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, pa
 
   return (
     <div className="pass-notes-section" style={{
-      marginTop: '16px',
-      padding: '0 4px',
-      borderTop: '1px solid #e2e8f0',
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column'
     }}>
       <h4 style={{
-        margin: '12px 0 12px 0',
+        margin: '0 0 12px 0',
         fontSize: '14px',
         fontWeight: '600',
         color: '#1f2937'
@@ -154,77 +154,79 @@ const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, pa
           Loading notes...
         </div>
       ) : (
-        <div style={{ marginBottom: '16px' }}>
-          <div style={{
-            display: 'flex',
-            gap: '12px',
-            alignItems: 'flex-start'
-          }}>
-            <textarea
-              value={noteText}
-              onChange={(e) => setNoteText(e.target.value)}
-              placeholder="Add notes about this sanding pass..."
-              rows={4}
-              style={{
-                flex: 1,
-                padding: '12px',
-                border: '1px solid #d1d5db',
-                borderRadius: '6px',
-                fontSize: '14px',
-                fontFamily: 'inherit',
-                resize: 'vertical',
-                outline: 'none',
-                boxSizing: 'border-box'
-              }}
-              onFocus={(e) => {
-                e.target.style.borderColor = '#3b82f6';
-                e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
-              }}
-              onBlur={(e) => {
-                e.target.style.borderColor = '#d1d5db';
-                e.target.style.boxShadow = 'none';
-              }}
-            />
-            
-            <button
-              onClick={saveNote}
-              disabled={saving || !canSave || showSuccess}
-              style={{
-                padding: '8px 16px',
-                color: 'white',
-                border: 'none',
-                borderRadius: '6px',
-                fontSize: '12px',
-                transition: 'background-color 0.2s',
-                height: 'fit-content',
-                whiteSpace: 'nowrap',
-                alignSelf: 'flex-end',
-                ...getButtonStyle()
-              }}
-              onMouseEnter={(e) => {
-                if (canSave && !saving && !showSuccess) {
-                  e.currentTarget.style.backgroundColor = '#2563eb';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (canSave && !saving && !showSuccess) {
-                  e.currentTarget.style.backgroundColor = '#3b82f6';
-                }
-              }}
-            >
-              {getButtonText()}
-            </button>
-          </div>
+        <div style={{ 
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+          minHeight: '120px'
+        }}>
+          <textarea
+            id={`pass-notes-${passId}`}
+            value={noteText}
+            onChange={(e) => setNoteText(e.target.value)}
+            placeholder="Add notes about this sanding pass..."
+            rows={4}
+            style={{
+              flexGrow: 1,
+              width: '100%',
+              padding: '12px',
+              border: '1px solid #d1d5db',
+              fontSize: '14px',
+              fontFamily: 'inherit',
+              resize: 'vertical',
+              outline: 'none',
+              boxSizing: 'border-box',
+              marginBottom: '8px'
+            }}
+            onFocus={(e) => {
+              e.target.style.borderColor = '#3b82f6';
+              e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
+            }}
+            onBlur={(e) => {
+              e.target.style.borderColor = '#d1d5db';
+              e.target.style.boxShadow = 'none';
+            }}
+          />
           
-          {error && (
-            <div style={{ 
-              marginTop: '8px'
-            }}>
+          <div style={{ 
+            display: 'flex', 
+            justifyContent: 'space-between', 
+            alignItems: 'center'
+          }}>
+            {error && (
               <span style={{ color: '#dc2626', fontSize: '13px' }}>
                 {error}
               </span>
+            )}
+            <div style={{ marginLeft: 'auto' }}>
+              <button
+                onClick={saveNote}
+                disabled={saving || !canSave || showSuccess}
+                style={{
+                  padding: '8px 16px',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  fontSize: '12px',
+                  transition: 'background-color 0.2s',
+                  whiteSpace: 'nowrap',
+                  ...getButtonStyle()
+                }}
+                onMouseEnter={(e) => {
+                  if (canSave && !saving && !showSuccess) {
+                    e.currentTarget.style.backgroundColor = '#2563eb';
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (canSave && !saving && !showSuccess) {
+                    e.currentTarget.style.backgroundColor = '#3b82f6';
+                  }
+                }}
+              >
+                {getButtonText()}
+              </button>
             </div>
-          )}
+          </div>
         </div>
       )}
     </div>

--- a/src/PassNotes.tsx
+++ b/src/PassNotes.tsx
@@ -1,0 +1,234 @@
+import React, { useState, useEffect } from 'react';
+import * as VIAM from "@viamrobotics/sdk";
+import { createNotesManager } from './lib/notesManager';
+
+interface PassNotesProps {
+  passId: string;
+  viamClient: VIAM.ViamClient;
+  machineId: string;
+  partId: string;
+}
+
+const PassNotes: React.FC<PassNotesProps> = ({ passId, viamClient, machineId, partId }) => {
+  const [noteText, setNoteText] = useState<string>('');
+  const [originalNoteText, setOriginalNoteText] = useState<string>(''); // Track original text
+  const [loading, setLoading] = useState<boolean>(true);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [showSuccess, setShowSuccess] = useState<boolean>(false); // Track success state
+  const [error, setError] = useState<string | null>(null);
+
+  const notesManager = createNotesManager(viamClient, machineId);
+
+  useEffect(() => {
+    const fetchNotes = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const notes = await notesManager.fetchPassNotes(passId);
+        
+        // Set the most recent note as the current text
+        if (notes.length > 0) {
+          const sortedNotes = notes.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+          const latestNoteText = sortedNotes[0].note_text;
+          setNoteText(latestNoteText);
+          setOriginalNoteText(latestNoteText); // Track original text
+        } else {
+          setNoteText('');
+          setOriginalNoteText('');
+        }
+      } catch (err) {
+        console.error("Error fetching notes:", err);
+        setError("Failed to load notes");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (passId && viamClient && machineId) {
+      fetchNotes();
+    }
+  }, [passId, viamClient, machineId]);
+
+  const saveNote = async () => {
+    if (!noteText.trim()) {
+      setError("Note cannot be empty");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    setShowSuccess(false);
+    
+    try {
+      await notesManager.savePassNote(passId, noteText.trim(), partId);
+      console.log("Note saved successfully!");
+      
+      // Update original text to current text
+      setOriginalNoteText(noteText.trim());
+      
+      // Show success state
+      setShowSuccess(true);
+      
+      // Reset success state after 2 seconds
+      setTimeout(() => {
+        setShowSuccess(false);
+      }, 2000);
+      
+    } catch (err) {
+      console.error("Error saving note:", err);
+      setError("Failed to save note");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Check if there are changes
+  const hasChanges = noteText.trim() !== originalNoteText.trim();
+  const canSave = hasChanges && noteText.trim().length > 0;
+
+  // Button styling based on state
+  const getButtonStyle = () => {
+    if (showSuccess) {
+      return {
+        backgroundColor: '#10b981', // Green for success
+        cursor: 'default'
+      };
+    } else if (saving) {
+      return {
+        backgroundColor: '#9ca3af', // Gray for saving
+        cursor: 'not-allowed'
+      };
+    } else if (canSave) {
+      return {
+        backgroundColor: '#3b82f6', // Blue for enabled
+        cursor: 'pointer'
+      };
+    } else {
+      return {
+        backgroundColor: '#9ca3af', // Gray for disabled
+        cursor: 'not-allowed'
+      };
+    }
+  };
+
+  const getButtonText = () => {
+    if (showSuccess) {
+      return 'Success';
+    } else if (saving) {
+      return (
+        <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+          <span style={{ 
+            display: 'inline-block',
+            width: '12px',
+            height: '12px',
+            border: '2px solid transparent',
+            borderTop: '2px solid white',
+            borderRadius: '50%',
+            animation: 'spin 1s linear infinite'
+          }}></span>
+          Saving...
+        </span>
+      );
+    } else {
+      return 'Save note';
+    }
+  };
+
+  return (
+    <div className="pass-notes-section" style={{
+      marginTop: '16px',
+      padding: '0 4px',
+      borderTop: '1px solid #e2e8f0',
+    }}>
+      <h4 style={{
+        margin: '12px 0 12px 0',
+        fontSize: '14px',
+        fontWeight: '600',
+        color: '#1f2937'
+      }}>
+        Notes for this pass
+      </h4>
+
+      {loading ? (
+        <div style={{ padding: '16px', textAlign: 'center', color: '#6b7280' }}>
+          Loading notes...
+        </div>
+      ) : (
+        <div style={{ marginBottom: '16px' }}>
+          <div style={{
+            display: 'flex',
+            gap: '12px',
+            alignItems: 'flex-start'
+          }}>
+            <textarea
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+              placeholder="Add notes about this sanding pass..."
+              rows={4}
+              style={{
+                flex: 1,
+                padding: '12px',
+                border: '1px solid #d1d5db',
+                borderRadius: '6px',
+                fontSize: '14px',
+                fontFamily: 'inherit',
+                resize: 'vertical',
+                outline: 'none',
+                boxSizing: 'border-box'
+              }}
+              onFocus={(e) => {
+                e.target.style.borderColor = '#3b82f6';
+                e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
+              }}
+              onBlur={(e) => {
+                e.target.style.borderColor = '#d1d5db';
+                e.target.style.boxShadow = 'none';
+              }}
+            />
+            
+            <button
+              onClick={saveNote}
+              disabled={saving || !canSave || showSuccess}
+              style={{
+                padding: '8px 16px',
+                color: 'white',
+                border: 'none',
+                borderRadius: '6px',
+                fontSize: '12px',
+                transition: 'background-color 0.2s',
+                height: 'fit-content',
+                whiteSpace: 'nowrap',
+                alignSelf: 'flex-end',
+                ...getButtonStyle()
+              }}
+              onMouseEnter={(e) => {
+                if (canSave && !saving && !showSuccess) {
+                  e.currentTarget.style.backgroundColor = '#2563eb';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (canSave && !saving && !showSuccess) {
+                  e.currentTarget.style.backgroundColor = '#3b82f6';
+                }
+              }}
+            >
+              {getButtonText()}
+            </button>
+          </div>
+          
+          {error && (
+            <div style={{ 
+              marginTop: '8px'
+            }}>
+              <span style={{ color: '#dc2626', fontSize: '13px' }}>
+                {error}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PassNotes;

--- a/src/PassNotes.tsx
+++ b/src/PassNotes.tsx
@@ -2,22 +2,24 @@ import React, { useState, useEffect } from 'react';
 import * as VIAM from "@viamrobotics/sdk";
 import { createNotesManager, PassNote } from './lib/notesManager';
 
-interface PassNotesProps {
+export interface PassNotesProps {
   passId: string;
   viamClient: VIAM.ViamClient;
   machineId: string;
   partId: string;
   initialNotes: PassNote[];
-  onNotesUpdate: (updater: (prevNotes: Map<string, PassNote[]>) => Map<string, PassNote[]>) => void;
+  isLoading: boolean;
+  onNotesUpdate: React.Dispatch<React.SetStateAction<Map<string, PassNote[]>>>;
 }
 
-const PassNotes: React.FC<PassNotesProps> = ({ 
-  passId, 
-  viamClient, 
-  machineId, 
-  partId, 
+const PassNotes: React.FC<PassNotesProps> = ({
+  passId,
+  viamClient,
+  machineId,
+  partId,
   initialNotes,
-  onNotesUpdate 
+  isLoading,
+  onNotesUpdate,
 }) => {
   const [noteText, setNoteText] = useState<string>('');
   const [originalNoteText, setOriginalNoteText] = useState<string>('');
@@ -28,6 +30,7 @@ const PassNotes: React.FC<PassNotesProps> = ({
   const notesManager = createNotesManager(viamClient, machineId);
 
   useEffect(() => {
+    // If we have initial notes, use them
     if (initialNotes.length > 0) {
       const sortedNotes = [...initialNotes].sort((a, b) => 
         new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
@@ -36,37 +39,38 @@ const PassNotes: React.FC<PassNotesProps> = ({
       setNoteText(latestNoteText);
       setOriginalNoteText(latestNoteText);
     } else {
+      // Don't fetch here - let AppInterface handle it
       setNoteText('');
       setOriginalNoteText('');
     }
-  }, [initialNotes]);
+  }, [passId, initialNotes]); // Add initialNotes to dependencies
 
   const saveNote = async () => {
+    if (saving) return; // Prevent double-clicks
+    
     setSaving(true);
     setError(null);
-    setShowSuccess(false);
+    setShowSuccess(false); // Reset success state
     
     try {
       const noteToSave = noteText.trim();
-      await notesManager.savePassNote(passId, noteToSave, partId);
       
+      // Get the created note directly from the savePassNote function
+      const newNote = await notesManager.savePassNote(passId, noteToSave, partId);
+      console.log("UI received saved note confirmation"); // Add this for debugging
+      
+      // Update UI state with the returned note object
       setOriginalNoteText(noteToSave);
       
-      const newNote: PassNote = {
-        pass_id: passId,
-        note_text: noteToSave,
-        created_at: new Date().toISOString(),
-        created_by: "web-app"
-      };
-      
-      onNotesUpdate((prevNotes: Map<string, PassNote[]>) => {
-        const newNotesMap = new Map(prevNotes);
-        const existingNotes = newNotesMap.get(passId) || [];
-        const updatedNotes = [newNote, ...existingNotes];
-        newNotesMap.set(passId, updatedNotes);
-        return newNotesMap;
+      // Update the notes collection with the new note
+      onNotesUpdate((prevNotes) => {
+        const newMap = new Map(prevNotes);
+        const currentNotes = newMap.get(passId) || [];
+        newMap.set(passId, [newNote, ...currentNotes]);
+        return newMap;
       });
       
+      // Show success state
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 2000);
       
@@ -74,6 +78,7 @@ const PassNotes: React.FC<PassNotesProps> = ({
       console.error("Error saving note:", err);
       setError("Failed to save note");
     } finally {
+      // Ensure this runs even if there's an error
       setSaving(false);
     }
   };
@@ -87,7 +92,7 @@ const PassNotes: React.FC<PassNotesProps> = ({
       return (
         <span style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
           <span style={{ 
-            display: 'inline-block',
+            display: 'block',
             width: '12px',
             height: '12px',
             border: '2px solid transparent',
@@ -109,99 +114,99 @@ const PassNotes: React.FC<PassNotesProps> = ({
   };
 
   return (
-    <div className="pass-notes-section" style={{
-      height: '100%',
-      display: 'flex',
-      flexDirection: 'column'
-    }}>
+    <div className="pass-notes-container">
       <h4 style={{
-        margin: '0 0 12px 0',
-        fontSize: '14px',
-        fontWeight: '600',
-        color: '#1f2937'
+        position: 'sticky',
+        top: 0,
+        backgroundColor: '#fafafa',
+        zIndex: 1,
+        margin: 0,
+        padding: '0 0 8px 4px',
       }}>
         Notes for this pass
       </h4>
-
-      <div style={{ 
-        display: 'flex',
-        flexDirection: 'column',
-        flex: 1,
-        minHeight: '120px'
-      }}>
-        <textarea
-          id={`pass-notes-${passId}`}
-          value={noteText}
-          onChange={(e) => setNoteText(e.target.value)}
-          placeholder="Add notes about this sanding pass..."
-          style={{
-            flexGrow: 1,
-            width: '100%',
-            padding: '12px',
-            border: '1px solid #d1d5db',
-            borderRadius: '6px',
-            fontSize: '14px',
-            fontFamily: 'inherit',
-            resize: 'vertical',
-            outline: 'none',
-            boxSizing: 'border-box',
-            marginBottom: '8px'
-          }}
-          onFocus={(e) => {
-            e.target.style.borderColor = '#3b82f6';
-            e.target.style.boxShadow = '0 0 0 3px rgba(59, 130, 246, 0.1)';
-          }}
-          onBlur={(e) => {
-            e.target.style.borderColor = '#d1d5db';
-            e.target.style.boxShadow = 'none';
-          }}
-        />
-        
-        <div style={{ 
-          display: 'flex', 
-          justifyContent: 'space-between', 
-          alignItems: 'center'
-        }}>
-          {error && (
-            <span style={{ color: '#dc2626', fontSize: '13px' }}>
-              {error}
-            </span>
-          )}
-          <div style={{ marginLeft: 'auto' }}>
-            <button
-              onClick={saveNote}
-              disabled={saving || !canSave || showSuccess}
-              style={{
-                padding: '6px 12px',
-                backgroundColor: getButtonColor(),
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                fontSize: '12px',
-                fontWeight: '500',
-                cursor: saving || !canSave || showSuccess ? 'not-allowed' : 'pointer',
-                transition: 'all 0.2s ease',
-                whiteSpace: 'nowrap',
-                lineHeight: '1.4'
-              }}
-              onMouseEnter={(e) => {
-                if (canSave && !saving && !showSuccess) {
-                  e.currentTarget.style.backgroundColor = '#2563eb';
-                  e.currentTarget.style.transform = 'translateY(-1px)';
-                }
-              }}
-              onMouseLeave={(e) => {
-                if (canSave && !saving && !showSuccess) {
-                  e.currentTarget.style.backgroundColor = '#3b82f6';
-                  e.currentTarget.style.transform = 'translateY(0)';
-                }
-              }}
-            >
-              {getButtonText()}
-            </button>
-          </div>
+      {isLoading && (
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', padding: '20px' }}>
+          <div style={{ 
+            display: 'inline-block',
+            width: '24px',
+            height: '24px',
+            border: '3px solid rgba(0,0,0,0.1)',
+            borderTop: '3px solid #3b82f6',
+            borderRadius: '50%',
+            animation: 'spin 1s linear infinite'
+          }}></div>
+          <span style={{ marginLeft: '10px', color: '#6b7280' }}>Loading notes...</span>
         </div>
-      </div>
+      )}
+      {!isLoading && (
+        <>
+          <textarea
+            value={noteText}
+            onChange={(e) => setNoteText(e.target.value)}
+            placeholder="Add notes about this pass..."
+            style={{
+              width: '100%',
+              height: '100px',
+              padding: '10px',
+              border: '1px solid #d1d5db',
+              borderRadius: '6px',
+              fontSize: '14px',
+              fontFamily: 'inherit',
+              resize: 'none',
+              outline: 'none',
+              transition: 'border-color 0.2s',
+            }}
+            onFocus={(e) => {
+              e.target.style.borderColor = '#3b82f6';
+            }}
+            onBlur={(e) => {
+              e.target.style.borderColor = '#d1d5db';
+            }}
+            disabled={saving}
+          />
+          
+          {/* Error message */}
+          {error && (
+            <div style={{
+              marginTop: '8px',
+              padding: '8px 12px',
+              backgroundColor: '#fee2e2',
+              color: '#991b1b',
+              borderRadius: '4px',
+              fontSize: '13px'
+            }}>
+              {error}
+            </div>
+          )}
+          
+          {/* Save button */}
+          <button
+            onClick={saveNote}
+            disabled={!canSave || saving}
+            style={{
+              marginTop: '12px',
+              padding: '10px 16px',
+              backgroundColor: getButtonColor(),
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              fontSize: '14px',
+              fontWeight: '500',
+              cursor: canSave && !saving ? 'pointer' : 'not-allowed',
+              opacity: canSave && !saving ? 1 : 0.5,
+              transition: 'all 0.2s',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '6px',
+              width: '100px'
+            }}
+          >
+            {getButtonText()}
+          </button>
+        </>
+      )}
     </div>
   );
 };

--- a/src/VideoModal.tsx
+++ b/src/VideoModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import * as VIAM from "@viamrobotics/sdk";
-import { extractCameraName } from './lib/videoUtils';
+// import { extractCameraName } from './lib/videoUtils';
 import { createVideoStreamFromBase64 } from './lib/videoUtils';
 
 interface VideoModalProps {

--- a/src/lib/notesManager.ts
+++ b/src/lib/notesManager.ts
@@ -1,0 +1,201 @@
+import * as VIAM from "@viamrobotics/sdk";
+
+export interface PassNote {
+  pass_id: string;
+  note_text: string;
+  created_at: string;
+  created_by: string;
+}
+
+export class NotesManager {
+  private viamClient: VIAM.ViamClient;
+  private machineId: string;
+
+  constructor(viamClient: VIAM.ViamClient, machineId: string) {
+    this.viamClient = viamClient;
+    this.machineId = machineId;
+  }
+
+  /**
+   * Save a note for a specific pass
+   */
+  async savePassNote(passId: string, noteText: string, partId: string): Promise<void> {
+    if (!this.viamClient) {
+      throw new Error("Viam client not initialized");
+    }
+
+    const now = new Date();
+    console.log(`Saving note for pass ${passId}: "${noteText}"`);
+
+    if (!partId) {
+      throw new Error("No part ID available for upload");
+    }
+
+    // Create a JSON note object
+    const noteData: PassNote = {
+      pass_id: passId,
+      note_text: noteText,
+      created_at: now.toISOString(),
+      created_by: "web-app"
+    };
+
+    // Convert to binary data (JSON string as bytes)
+    const noteJson = JSON.stringify(noteData);
+    const binaryData = new TextEncoder().encode(noteJson);
+
+    // Upload the note as binary data
+    await this.viamClient.dataClient.binaryDataCaptureUpload(
+      binaryData,                     // binary data
+      partId,                         // partId
+      "rdk:component:generic",        // componentType
+      "sanding-notes",                // componentName
+      "SaveNote",                     // methodName
+      ".json",                        // fileExtension
+      [now, now],                     // methodParameters (start and end time)
+      ["sanding-notes"]               // tags
+    );
+
+    console.log("Note saved successfully!");
+  }
+
+  /**
+   * Fetch all notes for a specific pass
+   */
+  async fetchPassNotes(passId: string): Promise<PassNote[]> {
+    if (!this.viamClient) {
+      throw new Error("Viam client not initialized");
+    }
+
+    // Use correct filter properties and cast to unknown first
+    const filter = {
+      robotId: this.machineId,
+      componentName: "sanding-notes",
+      componentType: "rdk:component:generic",
+      tags: ["sanding-notes"]
+    } as unknown as VIAM.dataApi.Filter;
+
+    const binaryData = await this.viamClient.dataClient.binaryDataByFilter(
+      filter,
+      100, // limit
+      VIAM.dataApi.Order.DESCENDING,
+      undefined, // no pagination token
+      false,
+      false,
+      false
+    );
+
+    // Filter and parse notes for this specific pass
+    const passNotes: PassNote[] = [];
+    for (const item of binaryData.data) {
+      try {
+        // Use binaryDataByIds to get the actual binary data
+        const noteDataArray = await this.viamClient.dataClient.binaryDataByIds([item.metadata!.binaryDataId!]);
+        if (noteDataArray.length > 0) {
+          // Properly access binary data from the response
+          const binaryDataItem = noteDataArray[0];
+          let noteBytes: Uint8Array;
+
+          if (binaryDataItem.binary) {
+            noteBytes = binaryDataItem.binary;
+          } else {
+            console.warn("No binary data found in response");
+            continue;
+          }
+
+          const noteJson = new TextDecoder().decode(noteBytes);
+          const noteData = JSON.parse(noteJson) as PassNote;
+
+          if (noteData.pass_id === passId) {
+            passNotes.push(noteData);
+          }
+        }
+      } catch (parseError) {
+        console.warn("Failed to parse note data:", parseError);
+      }
+    }
+
+    console.log("Retrieved notes:", passNotes);
+    return passNotes;
+  }
+
+  /**
+   * Fetch notes for multiple passes
+   */
+  async fetchNotesForPasses(passIds: string[]): Promise<Map<string, PassNote[]>> {
+    if (!this.viamClient) {
+      throw new Error("Viam client not initialized");
+    }
+
+    const filter = {
+      robotId: this.machineId,
+      componentName: "sanding-notes",
+      componentType: "rdk:component:generic",
+      tags: ["sanding-notes"]
+    } as unknown as VIAM.dataApi.Filter;
+
+    const binaryData = await this.viamClient.dataClient.binaryDataByFilter(
+      filter,
+      500, // higher limit for multiple passes
+      VIAM.dataApi.Order.DESCENDING,
+      undefined,
+      false,
+      false,
+      false
+    );
+
+    const notesByPassId = new Map<string, PassNote[]>();
+
+    // Initialize empty arrays for all requested pass IDs
+    passIds.forEach(passId => {
+      notesByPassId.set(passId, []);
+    });
+
+    // Parse and organize notes by pass ID
+    for (const item of binaryData.data) {
+      try {
+        const noteDataArray = await this.viamClient.dataClient.binaryDataByIds([item.metadata!.binaryDataId!]);
+        if (noteDataArray.length > 0) {
+          const binaryDataItem = noteDataArray[0];
+
+          if (binaryDataItem.binary) {
+            const noteJson = new TextDecoder().decode(binaryDataItem.binary);
+            const noteData = JSON.parse(noteJson) as PassNote;
+
+            // Only include notes for requested pass IDs
+            if (passIds.includes(noteData.pass_id)) {
+              const existingNotes = notesByPassId.get(noteData.pass_id) || [];
+              existingNotes.push(noteData);
+              notesByPassId.set(noteData.pass_id, existingNotes);
+            }
+          }
+        }
+      } catch (parseError) {
+        console.warn("Failed to parse note data:", parseError);
+      }
+    }
+
+    return notesByPassId;
+  }
+
+  /**
+   * Update an existing note (creates a new version)
+   */
+  async updatePassNote(passId: string, noteText: string, partId: string): Promise<void> {
+    // For now, just create a new note - in the future we could add versioning
+    await this.savePassNote(passId, noteText, partId);
+  }
+
+  /**
+   * Delete a note (not implemented yet - would require additional logic)
+   */
+  async deletePassNote(passId: string, noteId: string): Promise<void> {
+    throw new Error("Delete functionality not implemented yet");
+  }
+}
+
+/**
+ * Helper function to create a NotesManager instance
+ */
+export function createNotesManager(viamClient: VIAM.ViamClient, machineId: string): NotesManager {
+  return new NotesManager(viamClient, machineId);
+}

--- a/src/lib/notesManager.ts
+++ b/src/lib/notesManager.ts
@@ -184,13 +184,6 @@ export class NotesManager {
     // For now, just create a new note - in the future we could add versioning
     await this.savePassNote(passId, noteText, partId);
   }
-
-  /**
-   * Delete a note (not implemented yet - would require additional logic)
-   */
-  async deletePassNote(passId: string, noteId: string): Promise<void> {
-    throw new Error("Delete functionality not implemented yet");
-  }
 }
 
 /**

--- a/src/lib/videoUtils.ts
+++ b/src/lib/videoUtils.ts
@@ -1,11 +1,15 @@
 import * as VIAM from "@viamrobotics/sdk";
 import { Step } from "../AppInterface";
 
-export const createVideoStreamFromBase64 = (base64Data: Uint8Array): string | null => {
+export const createVideoStreamFromBase64 = (base64Data: Uint8Array | ArrayBuffer): string | null => {
   try {
     console.log("Creating video stream from base64...");
 
-    const blob = new Blob([base64Data], { type: 'video/mp4' });
+    const uint8 = base64Data instanceof Uint8Array ? base64Data : new Uint8Array(base64Data);
+    // Copy into a fresh ArrayBuffer to ensure it is an ArrayBuffer (not SharedArrayBuffer) acceptable as a BlobPart
+    const buffer = new ArrayBuffer(uint8.byteLength);
+    new Uint8Array(buffer).set(uint8);
+    const blob = new Blob([buffer], { type: 'video/mp4' });
     const url = URL.createObjectURL(blob);
 
     console.log("Video stream URL created successfully");
@@ -64,17 +68,17 @@ const formatDateToVideoStoreFormat = (date: Date): string => {
 };
 
 export const generateVideo = async (
-  videoStoreClient: VIAM.GenericComponentClient, 
+  videoStoreClient: VIAM.GenericComponentClient,
   step: Step) => {
-    console.log("generateVideo called for step", step);
-    console.log("formatDateToVideoStoreFormat(step.end)", formatDateToVideoStoreFormat(step.end));
-    console.log("formatDateToVideoStoreFormat(step.start)", formatDateToVideoStoreFormat(step.start));
-    const command = VIAM.Struct.fromJson({
-      "command": "save",
-      "to": formatDateToVideoStoreFormat(step.end),
-      "from": formatDateToVideoStoreFormat(step.start),
-      "metadata": `${step.pass_id}${step.name}`,
-    });
+  console.log("generateVideo called for step", step);
+  console.log("formatDateToVideoStoreFormat(step.end)", formatDateToVideoStoreFormat(step.end));
+  console.log("formatDateToVideoStoreFormat(step.start)", formatDateToVideoStoreFormat(step.start));
+  const command = VIAM.Struct.fromJson({
+    "command": "save",
+    "to": formatDateToVideoStoreFormat(step.end),
+    "from": formatDateToVideoStoreFormat(step.start),
+    "metadata": `${step.pass_id}${step.name}`,
+  });
 
-    return await videoStoreClient.doCommand(command);
-  };
+  return await videoStoreClient.doCommand(command);
+};


### PR DESCRIPTION
- Added editable notes section for each sanding pass alongside files section
- Notes are fetched once on initial load for all passes
- Saves notes with visual feedback (Success state, loading spinner)
- Supports empty notes to effectively "delete" entries
- 50/50 layout with files on left, notes on right

### New NotesManager class for note CRUD operations via Viam binary data API
- New [PassNotes](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) component with change detection and save states
- Notes stored as JSON in Viam binary data with tagging for retrieval

### UI/UX:
- Only enables save when changes detected
- Green success state for 2 seconds after save
- Files section converted to single column layout
- Proper error handling and loading states

<img width="1134" height="448" alt="image" src="https://github.com/user-attachments/assets/7b7d293d-fdd1-4253-a9da-b18d3c7e475b" />

<img width="570" height="218" alt="image" src="https://github.com/user-attachments/assets/fbf0a441-729b-42f5-8ee7-1277c15e2c13" />
<img width="570" height="221" alt="image" src="https://github.com/user-attachments/assets/218eb0a6-eb7a-4447-afc1-cbb62185a09f" />

[CONSULT-1554](https://viam.atlassian.net/browse/CONSULT-1554)